### PR TITLE
Fix always-on fan and add Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,8 @@
+all:
+	gcc -o remoteswitch rpi_pwr.c -lwiringPi -O3 -lpthread
+
+clean:
+	rm remoteswitch
+
+run:
+	sudo ./remoteswitch -r 17 -s 18 -n 4

--- a/rpi_pwr.c
+++ b/rpi_pwr.c
@@ -135,7 +135,7 @@ void Fan_Speed_Detect(void)
     if(err != 0)
     {
 		err_stop = 1;
-        printf("Fan Speed Modify Error:( %d - due to raspberrypi thremal manager),Reboot your pi and piboxy please.\n", err);
+        printf("Fan Speed Modify Error:( %d - due to raspberrypi thermal manager),Reboot your pi and piboxy please.\n", err);
     }
 
     fflush(stdout);


### PR DESCRIPTION
The confusing pwm_value calculation led to the fan basically always being on with nearly full speed. This PR fixes that and by default starts the fan at 65degC and scaling up the speed to full speed at 90degC.

I also added a very simple Makefile and fixed a typo.